### PR TITLE
Add confirmation dialog for reprocessing datasets

### DIFF
--- a/src/api/dataset.ts
+++ b/src/api/dataset.ts
@@ -50,6 +50,14 @@ export const rawOpticalImageQuery =
     }
   }`;
 
+export const resubmitDatasetQuery =
+  gql`mutation ($jwt: String!, $datasetId: String!, $name: String, 
+                $metadataJson: String, $delFirst: Boolean) {
+    resubmitDataset(jwt: $jwt, datasetId: $datasetId, name: $name, 
+                  metadataJson: $metadataJson, delFirst: $delFirst, 
+                  priority: 1)
+  }`;
+
 export const submitDatasetQuery =
   gql`mutation ($jwt: String!, $path: String!, $value: String!) {
     submitDataset(jwt: $jwt, path: $path, metadataJson: $value, priority: 1)

--- a/src/components/MetadataEditPage.vue
+++ b/src/components/MetadataEditPage.vue
@@ -1,6 +1,6 @@
 <template>
   <metadata-editor :datasetId="datasetId"
-                   :enableSubmit="loggedIn"
+                   :enableSubmit="loggedIn && !isSubmitting"
                    @submit="onSubmit"
                    disabledSubmitMessage="You must be logged in to perform this operation"
                    v-bind:validationErrors="validationErrors">
@@ -10,13 +10,15 @@
 <script>
  import MetadataEditor from './MetadataEditor.vue';
  import {getJWT} from '../util';
+ import {resubmitDatasetQuery} from '../api/dataset';
  import {updateMetadataQuery} from '../api/metadata';
 
  export default {
    name: 'metadata-edit-page',
    data() {
      return {
-       validationErrors: []
+       validationErrors: [],
+       isSubmitting: false
      }
    },
    computed: {
@@ -33,38 +35,87 @@
    },
 
    methods: {
-     onSubmit(datasetId, value) {
-       getJWT().then(jwt => this.updateMetadata(jwt, datasetId, value))
-               .then(() => {
-                 this.validationErrors = [];
-                 this.$message({
-                   message: 'Metadata was successfully updated!',
-                   type: 'success'
-                 });
-                 this.$router.go(-1);
-               }).catch(err => {
-                 console.log(err);
-                 const graphQLError = JSON.parse(err.graphQLErrors[0].message);
-                 if (graphQLError['type'] === 'failed_validation') {
-                   this.$message({
-                     message: 'Please fix the highlighted fields and submit again',
-                     type: 'error'
-                   });
-                 }
-                  // else if (graphQLError['type'] === 'submit_needed') {
-                  //   this.submitDataset(jwt, datasetId, ...)
-                  // }
-                  // else if (graphQLError['type'] === 'drop_submit_needed') {
-                  //   this.submitDataset(jwt, datasetId, ..., delFirst)
-                  // }
-                 else {
-                   this.$message({message: 'Couldn\'t save the form: GraphQL error', type: 'error'});
-                 }
-               });
+     async onSubmit(datasetId, value) {
+       // Prevent duplicate submissions if user double-clicks
+       if (this.isSubmitting) return;
+       this.isSubmitting = true;
+
+       try {
+         const jwt = await getJWT();
+         const wasSaved = await this.saveDataset(jwt, datasetId, value);
+
+         if (wasSaved) {
+           this.validationErrors = [];
+           this.$message({
+             message: 'Metadata was successfully updated!',
+             type: 'success'
+           });
+           this.$router.go(-1);
+         }
+       } catch(e) {
+         // Empty catch block needed because babel-plugin-component throws a
+         // compilation error when an async function has a try/finally without a catch.
+         // https://github.com/ElementUI/babel-plugin-component/issues/9
+       } finally {
+         this.isSubmitting = false;
+       }
      },
-     // submitDataset(jwt, dsId, ...) {
-     //
-     // },
+     async saveDataset(jwt, datasetId, value)
+     {
+       try {
+         await this.updateMetadata(jwt, datasetId, value);
+         return true;
+       } catch (err) {
+         console.log(err);
+         const graphQLError = JSON.parse(err.graphQLErrors[0].message);
+
+         if ((graphQLError['type'] === 'submit_needed' || graphQLError['type'] === 'drop_submit_needed')) {
+           if (await this.confirmReprocess()) {
+             const delFirst = graphQLError['type'] === 'drop_submit_needed';
+             await this.submitDataset(jwt, datasetId, value, delFirst);
+             return true;
+           }
+         } else if (graphQLError['type'] === 'failed_validation') {
+           this.$message({
+             message: 'Please fix the highlighted fields and submit again',
+             type: 'error'
+           });
+         } else {
+           this.$message({ message: 'Couldn\'t save the form: GraphQL error', type: 'error' });
+         }
+         return false;
+       }
+     },
+     async confirmReprocess() {
+       try {
+         await this.$confirm('The changes to the analysis options require the dataset to be reprocessed. ' +
+           'This dataset will be unavailable until reprocessing has completed. Do you wish to continue?',
+           'Reprocessing required',
+           {
+             type: 'warning',
+             confirmButtonText: 'Save',
+             cancelButtonText: 'Cancel'
+           });
+         return true;
+       } catch (e) {
+         // Ignore - user clicked cancel
+         return false;
+       }
+     },
+     submitDataset(jwt, datasetId, metadataJson, delFirst) {
+       const name = JSON.parse(metadataJson).metaspace_options.Dataset_Name;
+       return this.$apollo.mutate({
+         mutation: resubmitDatasetQuery,
+         variables: {jwt, datasetId, name, metadataJson, delFirst},
+         updateQueries: {
+           fetchMetadataQuery: (prev, _) => ({
+             dataset: {
+               metadataJSON: JSON.stringify(metadataJson)
+             }
+           })
+         }
+       });
+     },
      updateMetadata(jwt, dsId, value) {
        const dsName = JSON.parse(value).metaspace_options.Dataset_Name;
        return this.$apollo.mutate({


### PR DESCRIPTION
This also disables the submit button while submitting. Users have a tendency to double-click buttons and it can be a big issue when server requests are double-submitted.

Please also check if this text makes sense, uses the right terminology, etc:
![image](https://user-images.githubusercontent.com/26366936/38998124-30daa62c-43ef-11e8-84d0-cd9496ad0f00.png)
