### PR TITLE
Load default database from GraphQL

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,8 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="JSEqualityComparisonWithCoercion" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="mySeverity" value="All except when comparing with null" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,8 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <profile version="1.0">
-    <option name="myName" value="Project Default" />
-    <inspection_tool class="JSEqualityComparisonWithCoercion" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="mySeverity" value="All except when comparing with null" />
-    </inspection_tool>
-  </profile>
-</component>

--- a/src/api/metadata.ts
+++ b/src/api/metadata.ts
@@ -27,7 +27,7 @@ export const fetchOptionListsQuery = gql`{
   ionisationSources: metadataSuggestions(field: "MS_Analysis.Ionisation_Source", query: "", limit: 1000)
   maldiMatrices: metadataSuggestions(field: "Sample_Preparation.MALDI_Matrix", query: "", limit: 1000)
   analyzerTypes: metadataSuggestions(field: "MS_Analysis.Analyzer", query: "", limit: 1000)
-  molecularDatabases: molecularDatabases(hideDeprecated: false){name},
+  molecularDatabases: molecularDatabases(hideDeprecated: false){name, default},
   submitterNames: peopleSuggestions(role: SUBMITTER, query: "") {
     name
     surname

--- a/src/components/AnnotationView.ts
+++ b/src/components/AnnotationView.ts
@@ -125,7 +125,7 @@
        simpleQuery: ''
      };
      const path = '/annotations';
-     const q = encodeParams(filter, path)
+     const q = encodeParams(filter, path, this.$store.state.filterLists);
      return {query: q, path};
    }
 

--- a/src/components/FilterPanel.vue
+++ b/src/components/FilterPanel.vue
@@ -35,7 +35,6 @@
  import MzFilter from './MzFilter.vue';
  import SearchBox from './SearchBox.vue';
  import FILTER_SPECIFICATIONS from '../filterSpecs';
- import {fetchOptionListsQuery} from '../api/metadata';
  import deepcopy from 'deepcopy';
 
  const filterKeys = [
@@ -71,15 +70,8 @@
      MzFilter,
      SearchBox
    },
-   apollo: {
-     optionLists_: {
-       query: fetchOptionListsQuery,
-       update: data => data,
-       result({data}) {
-         if (data)
-           this.optionLists = deepcopy(data)
-       }
-     }
+   mounted() {
+     this.$store.dispatch('initFilterLists');
    },
    computed: {
      filter() {
@@ -109,8 +101,7 @@
 
    data () {
      return {
-       selectedFilterToAdd: null,
-       optionLists: null
+       selectedFilterToAdd: null
      }
    },
 
@@ -138,16 +129,17 @@
      },
 
      getFilterOptions(filter) {
+       const {filterLists} = this.$store.state;
        // dynamically generated options are supported:
        // either specify a function of optionLists or one of its field names
        if (typeof filter.options === 'object')
          return filter.options;
-       if (!this.optionLists)
+       if (filterLists == null)
          return [];
        if (typeof filter.options === 'string')
-         return this.optionLists[filter.options];
+         return filterLists[filter.options];
        else if (typeof filter.options === 'function') {
-         return filter.options(this.optionLists);
+         return filter.options(filterLists);
        }
        return [];
      }

--- a/src/components/MetadataEditor.vue
+++ b/src/components/MetadataEditor.vue
@@ -210,10 +210,12 @@
 
    created() {
      this.loading = true;
-     this.$apollo.query({query: gql`{molecularDatabases{name}}`}).then(response => {
+     this.$apollo.query({query: gql`{molecularDatabases{name, default}}`}).then(response => {
        Vue.set(this.schema.properties.metaspace_options.properties.Metabolite_Database.items,
                'enum',
                response.data.molecularDatabases.map(d => d.name));
+
+       this.applyDefaultDatabases(response.data.molecularDatabases);
        this.setLoadingStatus(false);
      }).catch(err => {
        console.log("Error fetching list of metabolite databases: ", err);
@@ -237,6 +239,7 @@
        const defaultValue = objectFactory(metadataSchema),
              value = this.fixEntries(JSON.parse(resp.data.dataset.metadataJson));
        this.value = merge({}, defaultValue, value);
+       this.defaultDatabaseApplied = true;
        this.setLoadingStatus(false);
      }).catch(err => {
        console.log("Error fetching current metadata: ", err);
@@ -247,7 +250,8 @@
      return {
        schema: metadataSchema,
        value: objectFactory(metadataSchema),
-       loading: true
+       loading: true,
+       defaultDatabaseApplied: false
      }
    },
    computed: {
@@ -334,6 +338,14 @@
        return value;
      },
 
+     applyDefaultDatabases(databases) {
+       if(databases && !this.defaultDatabaseApplied) {
+         const defaultDatabases = databases.filter(d => d.default).map(d => d.name);
+         this.value = merge({}, this.value, {metaspace_options: {Metabolite_Database: defaultDatabases}});
+         this.defaultDatabaseApplied = true;
+       }
+     },
+
      loadLastSubmission() {
        const defaultValue = objectFactory(metadataSchema);
        const lastValue = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || '{}');
@@ -345,7 +357,10 @@
          /* we want to have all nested fields to be present for convenience,
             that's what objectFactory essentially does */
          this.value = merge({}, defaultValue, this.fixEntries(lastValue));
+         this.applyDefaultDatabases(this.schema.properties.metaspace_options.properties.Metabolite_Database.items);
 
+         // If people have a saved form value, clear the database (instead of using the new default) to ensure
+         // that they're aware that the databases have changed.
          if (lastVersion < 2) {
            this.value.metaspace_options.Metabolite_Database = [];
          }

--- a/src/components/MetadataEditor.vue
+++ b/src/components/MetadataEditor.vue
@@ -214,8 +214,9 @@
        Vue.set(this.schema.properties.metaspace_options.properties.Metabolite_Database.items,
                'enum',
                response.data.molecularDatabases.map(d => d.name));
+       this.molecularDatabases = response.data.molecularDatabases;
 
-       this.applyDefaultDatabases(response.data.molecularDatabases);
+       this.applyDefaultDatabases();
        this.setLoadingStatus(false);
      }).catch(err => {
        console.log("Error fetching list of metabolite databases: ", err);
@@ -251,6 +252,7 @@
        schema: metadataSchema,
        value: objectFactory(metadataSchema),
        loading: true,
+       molecularDatabases: null,
        defaultDatabaseApplied: false
      }
    },
@@ -338,9 +340,9 @@
        return value;
      },
 
-     applyDefaultDatabases(databases) {
-       if(databases && !this.defaultDatabaseApplied) {
-         const defaultDatabases = databases.filter(d => d.default).map(d => d.name);
+     applyDefaultDatabases() {
+       if(this.molecularDatabases && !this.defaultDatabaseApplied) {
+         const defaultDatabases = this.molecularDatabases.filter(d => d.default).map(d => d.name);
          this.value = merge({}, this.value, {metaspace_options: {Metabolite_Database: defaultDatabases}});
          this.defaultDatabaseApplied = true;
        }
@@ -357,7 +359,7 @@
          /* we want to have all nested fields to be present for convenience,
             that's what objectFactory essentially does */
          this.value = merge({}, defaultValue, this.fixEntries(lastValue));
-         this.applyDefaultDatabases(this.schema.properties.metaspace_options.properties.Metabolite_Database.items);
+         this.applyDefaultDatabases();
 
          // If people have a saved form value, clear the database (instead of using the new default) to ensure
          // that they're aware that the databases have changed.

--- a/src/components/MetaspaceHeader.vue
+++ b/src/components/MetaspaceHeader.vue
@@ -82,7 +82,7 @@
 
 <script>
  import FILTER_SPECIFICATIONS from '../filterSpecs.js';
- import {encodeParams, DEFAULT_FILTER} from '../url';
+ import {encodeParams} from '../url';
  import {getJWT, decodePayload} from '../util';
 
  export default {
@@ -119,10 +119,10 @@
      href(path) {
        const lastParams = this.$store.state.lastUsedFilters[path];
        let f = lastParams ? lastParams.filter : {}
-       f = Object.assign({}, DEFAULT_FILTER, f, this.$store.getters.filter)
+       f = Object.assign({}, f, this.$store.getters.filter)
        const link = {
          path,
-         query: encodeParams(f, path)
+         query: encodeParams(f, path, this.$store.state.filterLists)
        };
        return link;
      },

--- a/src/components/SingleSelectFilter.vue
+++ b/src/components/SingleSelectFilter.vue
@@ -2,7 +2,7 @@
   <tag-filter :name="name" :removable="removable"
               @destroy="destroy">
     <el-select slot="edit"
-               :filterable="filterable" :clearable="clearable" v-model="value2">
+               :filterable="filterable" :clearable="clearable" :value="value" @change="onChange">
       <el-option v-for="item in options"
                  :label="formatOption(item)" :value="item" :key="item">
       </el-option>
@@ -30,6 +30,10 @@
    components: {
      TagFilter
    },
+   model: {
+     prop: 'value',
+     event: 'change'
+   },
    props: {
      name: String,
      options: Array,
@@ -40,19 +44,10 @@
      removable: {type: Boolean, default: true},
      filterable: {type: Boolean, default: true}
    },
-   data() {
-     return {
-       value2: this.value
-     };
-   },
-   watch: {
-     // TODO: why :value="value" + @change="onChange" doesn't work?
-     value2(val) {
-       this.$emit('input', val);
-       this.$emit('change', val);
-     }
-   },
    methods: {
+     onChange(val: Option) {
+       this.$emit('change', val);
+     },
      formatOption(option: Option): string {
        if (this.optionFormatter)
          return this.optionFormatter(option);

--- a/src/filterSpecs.js
+++ b/src/filterSpecs.js
@@ -67,7 +67,9 @@ const FILTER_SPECIFICATIONS = {
     name: 'Database',
     description: 'Select database',
     levels: ['annotation'],
-    initialValue: 'HMDB-v2.5', // because we've agreed to process every dataset with it
+    initialValue: lists => lists.molecularDatabases
+                                .filter(d => d.default)
+                                .map(d => d.name)[0],
 
     options: lists => lists.molecularDatabases.map(d => d.name),
     removable: false

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,1 +1,18 @@
-export default {};
+import apolloClient from '../graphqlClient';
+import {fetchOptionListsQuery} from '../api/metadata';
+
+export default {
+
+  async initFilterLists(context) {
+    if(context.state.filterListsLoading || context.state.filterLists != null)
+      return;
+
+    context.commit('setFilterListsLoading');
+
+    const response = await apolloClient.query({
+      query: fetchOptionListsQuery
+    });
+
+    context.commit('setFilterLists', response.data);
+  }
+};

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,5 +1,6 @@
 import apolloClient from '../graphqlClient';
 import {fetchOptionListsQuery} from '../api/metadata';
+import {decodeParams} from '../url';
 
 export default {
 
@@ -14,5 +15,8 @@ export default {
     });
 
     context.commit('setFilterLists', response.data);
+    // Refresh the current filter so that computed defaults that depend on `filterLists` are applied
+    const filter = decodeParams(context.state.route, context.state.filterLists)
+    context.commit('updateFilter', filter)
   }
 };

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -3,7 +3,7 @@ import {decodeParams, decodeSettings} from '../url';
 
 export default {
   filter(state) {
-    return decodeParams(state.route);
+    return decodeParams(state.route, state.filterLists);
   },
 
   settings(state) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,11 +4,15 @@ Vue.use(Vuex);
 
 import getters from './getters.js';
 import mutations from './mutations.js';
+import actions from './actions.js';
 
 const store = new Vuex.Store({
   state: {
     // names of currently shown filters
     orderedActiveFilters: [],
+
+    filterLists: null,
+    filterListsLoading: false,
 
     // currently selected annotation
     annotation: undefined,
@@ -25,7 +29,8 @@ const store = new Vuex.Store({
   },
 
   getters,
-  mutations
+  mutations,
+  actions
 })
 
 export default store;

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -1,12 +1,11 @@
 import router from '../router';
 
-import FILTER_SPECIFICATIONS from '../filterSpecs';
 import {decodeParams,
         encodeParams, encodeSections, encodeSortOrder,
         stripFilteringParams} from '../url';
 
 function updatedLocation(state, filter) {
-  let query = encodeParams(filter, state.route.path);
+  let query = encodeParams(filter, state.route.path, state.filterLists);
 
   state.lastUsedFilters[state.route.path] = {
     filter,
@@ -58,17 +57,10 @@ export default {
   },
 
   addFilter (state, name) {
-    let {initialValue} = FILTER_SPECIFICATIONS[name];
-    if(typeof initialValue === 'function') {
-      if(state.filterLists != null) {
-        initialValue = initialValue(state.filterLists);
-      } else {
-        initialValue = null;
-      }
-    }
+    const initialValue = getFilterInitialValue(name, state.filterLists);
 
     // FIXME: is there any way to access getters here?
-    let filter = Object.assign(decodeParams(state.route),
+    let filter = Object.assign(decodeParams(state.route, state.filterLists),
                                {[name]: initialValue});
 
     state.orderedActiveFilters.push(name);

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -3,6 +3,7 @@ import router from '../router';
 import {decodeParams,
         encodeParams, encodeSections, encodeSortOrder,
         stripFilteringParams} from '../url';
+import {getFilterInitialValue} from '../filterSpecs';
 
 function updatedLocation(state, filter) {
   let query = encodeParams(filter, state.route.path, state.filterLists);

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -58,13 +58,30 @@ export default {
   },
 
   addFilter (state, name) {
-    const {initialValue} = FILTER_SPECIFICATIONS[name];
+    let {initialValue} = FILTER_SPECIFICATIONS[name];
+    if(typeof initialValue === 'function') {
+      if(state.filterLists != null) {
+        initialValue = initialValue(state.filterLists);
+      } else {
+        initialValue = null;
+      }
+    }
+
     // FIXME: is there any way to access getters here?
     let filter = Object.assign(decodeParams(state.route),
                                {[name]: initialValue});
 
     state.orderedActiveFilters.push(name);
     pushURL(state, filter);
+  },
+
+  setFilterListsLoading(state) {
+    state.filterListsLoading = true;
+  },
+
+  setFilterLists(state, filterLists) {
+    state.filterLists = filterLists;
+    state.filterListsLoading = false;
   },
 
   setAnnotation(state, annotation) {


### PR DESCRIPTION
This removes the use of the default database in `metadata` and refactors code as needed to dynamically populate the default database once the `molecularDatabases` query has finished.

* Moved the lookup lists from `FilterPanel`'s data into vuex. This was needed as the selected filters are managed in vuex.
* Changed `SingleSelectFilter` to directly use `value` instead of mapping it through a `value2` data. This seemed to work fine, I guess it was fixed some time between us upgrading from Vue 2.1 to Vue 2.5
* Removed `DEFAULT_FILTER`, replacing it with a `defaultInLevels` field to `filterSpecs.js` so that the default values could be calculated by the `initialValue` callback