### PR TITLE
Database descriptions

### DIFF
--- a/src/components/DatabaseDescriptions.vue
+++ b/src/components/DatabaseDescriptions.vue
@@ -1,0 +1,107 @@
+<template>
+  <div class="desc-popover">
+    <p>
+      Database selection determines which metabolites can be annotated.
+      Many databases are for specific types of sample, please see their respective webpages for details.
+      We show either the version number or a time-stamped date of export.<br/>
+      <b>HMDB-v4</b> is the best choice for most mammalian datasets.
+    </p>
+    <div>
+      <b>Brassica Napus database (BraChemDB):</b>
+      A curated rapeseed database from LC-MS/MS measurements.
+      <el-popover trigger="hover" placement="top">
+        <div class="desc-cite-popover">University of Rennes 1</div>
+        <span slot="reference" class="desc-cite">Cite</span>
+      </el-popover>
+    </div>
+    <div>
+      <b><a href="https://www.ebi.ac.uk/chebi/aboutChebiForward.do">Chemical Entities of Biological Interest (ChEBI)</a>:</b>
+      ChEBI is a database and ontology of products of nature or synthetic products used to intervene in the processes of living organisms.
+      <el-popover trigger="hover" placement="top">
+        <div class="desc-cite-popover">
+          Hastings J, Owen G, Dekker A, Ennis M, Kale N, Muthukrishnan V, Turner S, Swainston N, Mendes P, Steinbeck C. (2016).
+          ChEBI in 2016: Improved services and an expanding collection of metabolites.
+          <a href="http://europepmc.org/abstract/MED/26467479">Nucleic Acids Res.</a>
+        </div>
+        <span slot="reference" class="desc-cite">Cite</span>
+      </el-popover>
+    </div>
+    <div>
+      <b><a href="http://www.hmdb.ca/about">Human Metabolome Database (HMDB)</a>:</b>
+      Database containing small molecule metabolites known to be in the human body.
+      <b>HMDB-endogenous</b> is a filtered version of HMDB that contains only molecules labelled in the database as endogenously produced.
+      <el-popover trigger="hover" placement="top">
+        <div class="desc-cite-popover">
+          Wishart DS, Feunang YD, Marcu A, Guo AC, Liang K, et al.,
+          HMDB 4.0 &mdash; The Human Metabolome Database for 2018.
+          Nucleic Acids Res. 2018. Jan 4;46(D1):D608-17.
+          <a href="http://www.ncbi.nlm.nih.gov/pubmed/29140435">29140435</a>
+        </div>
+        <span slot="reference" class="desc-cite">Cite</span>
+      </el-popover>
+    </div>
+    <div>
+      <b><a href="http://www.lipidmaps.org/data/databases.html">LIPID Metabolites And Pathways Strategy (LipidMaps)</a>:</b>
+      An experimentally determined list of all of the major and many minor lipid species in mammalian cells.
+      <el-popover trigger="hover" placement="top">
+        <div class="desc-cite-popover">
+          LIPID MAPS structure database.
+          Sud M., Fahy E., Cotter D., Brown A., Dennis E., Glass C., Murphy R., Raetz C., Russell D., and Subramaniam S.,
+          Nucleic Acids Research 35, D527-32 (2006)
+        </div>
+        <span slot="reference" class="desc-cite">Cite</span>
+      </el-popover>
+    </div>
+    <div>
+      <b><a href="http://pseudomonas.umaryland.edu/PAMDB">Pseudomonas aeruginosa Metabolome Database (PAMDB)</a>:</b>
+      An experimentally determined database containing extensive metabolomic data and metabolic pathway diagrams about 
+      Pseudomonas aeruginosa (reference strain PAO1).
+      <el-popover trigger="hover" placement="top">
+        <div class="desc-cite-popover">
+          Weiliang Huang, Luke K. Brewer, Jace W. Jones, Angela T. Nguyen, Ana Marcu, David S. Wishart,
+          Amanda G. Oglesby-Sherrouse, Maureen A. Kane, and Angela Wilks (2018).
+          PAMDB: a comprehensive Pseudomonas aeruginosa metabolome database.
+          Nucleic Acids Res. 46(D1):D575-D580.
+          DOI: <a href="https://academic.oup.com/nar/article-lookup/doi/10.1093/nar/gkx1061">10.1093/nar/gkx1061</a>
+        </div>
+        <span slot="reference" class="desc-cite">Cite</span>
+      </el-popover>
+    </div>
+    <div>
+      <b><a href="http://www.swisslipids.org/#/about">SwissLipids</a>:</b>
+      The set of known, expert curated lipids provided plus a library of theoretical lipid structures.
+      <el-popover trigger="hover" placement="top">
+        <div class="desc-cite-popover">
+          Lucila Aimo, Robin Liechti, Nevila Hyka-Nouspikel, Anne Niknejad, Anne Gleizes, Lou Götz, Dmitry Kuznetsov,
+          Fabrice P.A. David, F. Gisou van der Goot, Howard Riezman, Lydie Bougueleret, Ioannis Xenarios, Alan Bridge;
+          The SwissLipids knowledgebase for lipid biology, <i>Bioinformatics</i>,
+          Volume 31, Issue 17, 1 September 2015, Pages 2860–2866,
+          <a href="https://doi.org/10.1093/bioinformatics/btv285">https://doi.org/10.1093/bioinformatics/btv285</a>
+        </div>
+        <span slot="reference" class="desc-cite">Cite</span>
+      </el-popover>
+    </div>
+  </div>
+</template>
+<script>
+  export default {
+    name: 'database-descriptions'
+  };
+</script>
+<style>
+  .desc-popover {
+    width: 80vh;
+    max-width: 600px;
+    word-break: normal;
+    text-align: left;
+  }
+  .desc-cite-popover {
+    max-width: 400px;
+    word-break: normal;
+    text-align: left;
+  }
+  .desc-cite {
+    text-decoration: dotted underline;
+    cursor: pointer;
+  }
+</style>

--- a/src/components/MetadataEditor.vue
+++ b/src/components/MetadataEditor.vue
@@ -164,8 +164,6 @@
  import Vue from 'vue';
  import DatabaseDescriptions from './DatabaseDescriptions.vue';
 
- //TODO Lachlan: Consolidate hard-coded data into its own file, using full paths instead of field names and
- // components instead of HTML snippets.
  const FIELD_WIDTH = {
    'Institution': 6,
    'Submitter': 9,
@@ -292,8 +290,6 @@
 
        if (this.isRequired(propName, parent))
          name += '<span style="color: red">*</span>';
-
-
        return name;
      },
 

--- a/src/components/MetadataEditor.vue
+++ b/src/components/MetadataEditor.vue
@@ -20,7 +20,13 @@
             <el-col :span="getWidth(propName)"
                     v-for="(prop, propName) in section.properties"
                     :key="sectionName + propName">
-              <div class="field-label" v-html="prettify(propName, section)"></div>
+              <div class="field-label">
+                <span v-html="prettify(propName, section)"></span>
+                <el-popover trigger="hover" placement="right" v-if="getHelp(propName)">
+                  <div v-html="getHelp(propName)"></div>
+                  <i slot="reference" class="el-icon-question"></i>
+                </el-popover>
+              </div>
 
               <el-form-item class="control" v-if="prop.type == 'string' && !loading"
                             :class="isError(sectionName, propName)">
@@ -157,6 +163,8 @@
  import gql from 'graphql-tag';
  import Vue from 'vue';
 
+ //TODO Lachlan: Consolidate hard-coded data into its own file, using full paths instead of field names and
+ // components instead of HTML snippets.
  const FIELD_WIDTH = {
    'Institution': 6,
    'Submitter': 9,
@@ -173,6 +181,41 @@
    'Resolving_Power': 12,
    'Dataset_Name': 7,
  };
+
+ const FIELD_HELP = {
+   'Metabolite_Database': `
+   <div class="md-editor-tooltip">
+     <p>
+       The database selection determines which metabolites will be annotated.
+       Many databases are for specific types of sample, please see their respective webpages for details.
+       <b>HMDB-v4</b> is the best choice for most datasets.
+     </p>
+     <p>
+       <b>Brassica Napus database (BraChemDB):</b>
+       A curated rapeseed database from LC-MS/MS measurements.
+     </p>
+     <p>
+       <b><a href="https://www.ebi.ac.uk/chebi/aboutChebiForward.do">Chemical Entities of Biological Interest (ChEBI)</a>:</b>
+        ChEBI is a database and ontology containing information about chemical entities of biological interest, each of which is classified within the ontology and assigned multiple annotations including (where relevant) a chemical structure, database cross-references, synonyms and literature citations.
+     </p>
+     <p>
+       <b><a href="http://www.hmdb.ca/about">Human Metabolome Database (HMDB)</a>:</b>
+       Database containing detailed information about small molecule metabolites found in the human body. The database is designed to contain or link three kinds of data: 1) chemical data, 2) clinical data, and 3) molecular biology/biochemistry data. The database contains 114,064 metabolite entries including both water-soluble and lipid soluble metabolites as well as metabolites that would be regarded as either abundant (> 1 uM) or relatively rare (< 1 nM).  HMDB-endogenous is a filtered version of HMDB that contains only those molecules labelled in the database as endogenously produced.
+     </p>
+     <p>
+       <b><a href="http://www.lipidmaps.org/data/databases.html">LIPID Metabolites And Pathways Strategy (LipidMaps)</a>:</b>
+       A multi-institutional effort created in 2003 to identify and quantitate, using a systems biology approach and sophisticated mass spectrometers, all of the major — and many minor — lipid species in mammalian cells.
+     </p>
+     <p>
+       <b><a href="http://pseudomonas.umaryland.edu/">Pseudomonas aeruginosa Metabolome Database (PAMDB)</a>:</b>
+       The PAMDB is an expertly curated database containing extensive metabolomic data and metabolic pathway diagrams about Pseudomonas aeruginosa (reference strain PAO1).
+     </p>
+     <p>
+       <b><a href="http://www.swisslipids.org/#/about">SwissLipids</a>:</b>
+       An expert curated resource that provides a framework for the integration of lipid and lipidomic data with biological knowledge and models.  Information about known lipids, including knowledge of lipid structures, metabolism, interactions, and subcellular and tissular localization is curated from peer-reviewed literature. The set of known, expert curated lipids provided by SwissLipids is complemented by a library of theoretical lipid structures.
+     </p>
+   </div>`
+ }
 
  function objectFactory(schema) {
    let obj = {};
@@ -279,7 +322,13 @@
 
        if (this.isRequired(propName, parent))
          name += '<span style="color: red">*</span>';
+
+
        return name;
+     },
+
+     getHelp(propName) {
+       return FIELD_HELP[propName];
      },
 
      getWidth(propName) {
@@ -439,6 +488,13 @@
  #md-editor-submit > button {
    width: 100px;
    padding: 6px;
+ }
+
+ .md-editor-tooltip {
+   width: 80vh;
+   max-width: 600px;
+   word-break: normal;
+   text-align: left;
  }
 
  .control.el-form-item, .subfield > .el-form-item {

--- a/src/components/MetadataEditor.vue
+++ b/src/components/MetadataEditor.vue
@@ -23,8 +23,8 @@
               <div class="field-label">
                 <span v-html="prettify(propName, section)"></span>
                 <el-popover trigger="hover" placement="right" v-if="getHelp(propName)">
-                  <div v-html="getHelp(propName)"></div>
-                  <i slot="reference" class="el-icon-question"></i>
+                  <component :is="getHelp(propName)"></component>
+                  <i slot="reference" class="el-icon-question field-label-help"></i>
                 </el-popover>
               </div>
 
@@ -162,6 +162,7 @@
  } from '../api/metadata';
  import gql from 'graphql-tag';
  import Vue from 'vue';
+ import DatabaseDescriptions from './DatabaseDescriptions.vue';
 
  //TODO Lachlan: Consolidate hard-coded data into its own file, using full paths instead of field names and
  // components instead of HTML snippets.
@@ -183,38 +184,7 @@
  };
 
  const FIELD_HELP = {
-   'Metabolite_Database': `
-   <div class="md-editor-tooltip">
-     <p>
-       The database selection determines which metabolites will be annotated.
-       Many databases are for specific types of sample, please see their respective webpages for details.
-       <b>HMDB-v4</b> is the best choice for most datasets.
-     </p>
-     <p>
-       <b>Brassica Napus database (BraChemDB):</b>
-       A curated rapeseed database from LC-MS/MS measurements.
-     </p>
-     <p>
-       <b><a href="https://www.ebi.ac.uk/chebi/aboutChebiForward.do">Chemical Entities of Biological Interest (ChEBI)</a>:</b>
-        ChEBI is a database and ontology containing information about chemical entities of biological interest, each of which is classified within the ontology and assigned multiple annotations including (where relevant) a chemical structure, database cross-references, synonyms and literature citations.
-     </p>
-     <p>
-       <b><a href="http://www.hmdb.ca/about">Human Metabolome Database (HMDB)</a>:</b>
-       Database containing detailed information about small molecule metabolites found in the human body. The database is designed to contain or link three kinds of data: 1) chemical data, 2) clinical data, and 3) molecular biology/biochemistry data. The database contains 114,064 metabolite entries including both water-soluble and lipid soluble metabolites as well as metabolites that would be regarded as either abundant (> 1 uM) or relatively rare (< 1 nM).  HMDB-endogenous is a filtered version of HMDB that contains only those molecules labelled in the database as endogenously produced.
-     </p>
-     <p>
-       <b><a href="http://www.lipidmaps.org/data/databases.html">LIPID Metabolites And Pathways Strategy (LipidMaps)</a>:</b>
-       A multi-institutional effort created in 2003 to identify and quantitate, using a systems biology approach and sophisticated mass spectrometers, all of the major — and many minor — lipid species in mammalian cells.
-     </p>
-     <p>
-       <b><a href="http://pseudomonas.umaryland.edu/">Pseudomonas aeruginosa Metabolome Database (PAMDB)</a>:</b>
-       The PAMDB is an expertly curated database containing extensive metabolomic data and metabolic pathway diagrams about Pseudomonas aeruginosa (reference strain PAO1).
-     </p>
-     <p>
-       <b><a href="http://www.swisslipids.org/#/about">SwissLipids</a>:</b>
-       An expert curated resource that provides a framework for the integration of lipid and lipidomic data with biological knowledge and models.  Information about known lipids, including knowledge of lipid structures, metabolism, interactions, and subcellular and tissular localization is curated from peer-reviewed literature. The set of known, expert curated lipids provided by SwissLipids is complemented by a library of theoretical lipid structures.
-     </p>
-   </div>`
+   'Metabolite_Database': DatabaseDescriptions
  }
 
  function objectFactory(schema) {
@@ -461,6 +431,10 @@
    padding: 0px 0px 3px 5px;
  }
 
+ .field-label-help {
+   cursor: pointer;
+ }
+
  .subfield {
    padding-right: 10px;
  }
@@ -488,13 +462,6 @@
  #md-editor-submit > button {
    width: 100px;
    padding: 6px;
- }
-
- .md-editor-tooltip {
-   width: 80vh;
-   max-width: 600px;
-   word-break: normal;
-   text-align: left;
  }
 
  .control.el-form-item, .subfield > .el-form-item {


### PR DESCRIPTION
Adds help text next to the database selector:
![image](https://user-images.githubusercontent.com/26366936/39534061-fd36343e-4e30-11e8-8227-893c54ee5fab.png)

With citations:
![image](https://user-images.githubusercontent.com/26366936/39534099-0b9bcaca-4e31-11e8-8a8c-5dd974c6dc9a.png)

I made several changes from the [source document](https://docs.google.com/document/d/1yrr7N3eJhUeqryplktVqmaMjizEtPjKWrex3s8wCUbY/edit):

* Changed the links to point to the "About" pages for many of the datasets, as they seemed to be  better at answering the question "do I want to use this database?".
* Changed "(LIPID MAPS)" to "(LipidMaps)" to match the database name in the selector
* Grabbed another copy of the SwissLipids citation, as the source document was missing commas