### PR TITLE
Notification filtering

### DIFF
--- a/src/components/DatasetItem.vue
+++ b/src/components/DatasetItem.vue
@@ -115,7 +115,10 @@
         <a @click="openDeleteDialog">Delete dataset</a>
       </div>
 
-      <img v-if="!dataset.isPublic" class="ds-item-private-icon" src="../assets/padlock-icon.svg">
+      <img v-if="!dataset.isPublic"
+           class="ds-item-private-icon"
+           src="../assets/padlock-icon.svg"
+           title="These annotation results are not publicly visible">
     </div>
   </div>
 </template>

--- a/src/components/DatasetTable.vue
+++ b/src/components/DatasetTable.vue
@@ -125,16 +125,6 @@
 
    apollo: {
      $subscribe: {
-       datasetDeleted: {
-         query: gql`subscription DD {
-           datasetDeleted { datasetId }
-         }`,
-         result(data) {
-           console.log(data);
-           this.refetchList();
-         }
-       },
-
        datasetStatusUpdated: {
          query: gql`subscription DS {
            datasetStatusUpdated {
@@ -151,27 +141,26 @@
            }
          }`,
          result(data) {
-           console.log(data);
-           const {
-             id, name, status, submitter, institution
-           } = data.datasetStatusUpdated.dataset;
-           const who = `${submitter.name} ${submitter.surname} (${institution})`;
-           const statusMap = {
-             FINISHED: 'success',
-             QUEUED: 'info',
-             STARTED: 'info',
-             FAILED: 'warning'
-           };
-           let message = '';
-           if (status == 'FINISHED')
-             message = `Processing of dataset ${name} is finished!`;
-           else if (status == 'FAILED')
-             message = `Something went wrong with dataset ${name} :(`;
-           else if (status == 'QUEUED')
-             message = `Dataset ${name} has been submitted to query by ${who}`;
-           else if (status == 'STARTED')
-             message = `Started processing dataset ${name}`;
-           this.$notify({ message, type: statusMap[status] });
+           if (data.datasetStatusUpdated.dataset != null) {
+             const {name, status, submitter, institution} = data.datasetStatusUpdated.dataset;
+             const who = `${submitter.name} ${submitter.surname} (${institution})`;
+             const statusMap = {
+               FINISHED: 'success',
+               QUEUED: 'info',
+               STARTED: 'info',
+               FAILED: 'warning'
+             };
+             let message = '';
+             if (status == 'FINISHED')
+               message = `Processing of dataset ${name} is finished!`;
+             else if (status == 'FAILED')
+               message = `Something went wrong with dataset ${name} :(`;
+             else if (status == 'QUEUED')
+               message = `Dataset ${name} has been submitted to query by ${who}`;
+             else if (status == 'STARTED')
+               message = `Started processing dataset ${name}`;
+             this.$notify({ message, type: statusMap[status] });
+           }
 
            this.refetchList();
          }


### PR DESCRIPTION
Asana task: https://app.asana.com/0/597480600201879/662047100332398

* Added a tooltip to the padlock icon on private datasets
* Changed `datasetStatusUpdate` subscription to handle empty payloads. Updates with empty payloads are now used to indicate a data change that the current user can't see, e.g. a dataset becoming private or being deleted.
* Removed the `datasetDeleted` subscription, as it doesn't make sense to distinguish between "it was deleted" and "it was made private and you can't see it anymore".

This change relies on graphql changes. Once these changes have been merged, the private prototype is ready for deployment to staging.