### PR TITLE
Resilient JWT handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ const AWS = require('aws-sdk'),
 const env = process.env.NODE_ENV || 'development';
 const conf = require('./conf.js');
 
-const LOCAL_SETUP = false;//conf.UPLOAD_DESTINATION !== 's3';
+const LOCAL_SETUP = conf.UPLOAD_DESTINATION !== 's3';
 
 const configureSession = (app) => {
   let sessionStore = undefined;

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ const AWS = require('aws-sdk'),
 const env = process.env.NODE_ENV || 'development';
 const conf = require('./conf.js');
 
-const LOCAL_SETUP = conf.UPLOAD_DESTINATION !== 's3';
+const LOCAL_SETUP = false;//conf.UPLOAD_DESTINATION !== 's3';
 
 const configureSession = (app) => {
   let sessionStore = undefined;

--- a/src/components/MetaspaceHeader.vue
+++ b/src/components/MetaspaceHeader.vue
@@ -154,18 +154,11 @@
      },
 
      login() {
-       getJWT().then(jwt => {
-         const {name, email, role} = decodePayload(jwt);
-         if (role != 'anonymous') {
-           this.$store.commit('login', {name, email, role});
-         }
-       })
+       this.$store.dispatch('loadUser');
      },
 
      logout() {
-       fetch('/logout', {credentials: 'include'}).then(() => {
-         this.$store.commit('logout');
-       });
+       this.$store.dispatch('logout');
      }
    }
  }

--- a/src/components/MetaspaceHeader.vue
+++ b/src/components/MetaspaceHeader.vue
@@ -81,9 +81,8 @@
 </template>
 
 <script>
- import FILTER_SPECIFICATIONS from '../filterSpecs.js';
  import {encodeParams} from '../url';
- import {getJWT, decodePayload} from '../util';
+ import tokenAutorefresh from '../tokenAutorefresh';
 
  export default {
    name: 'metaspace-header',
@@ -113,10 +112,6 @@
      return {
        loginEmail: (this.$store.state.user ? this.$store.state.user.email : '')
      };
-   },
-
-   mounted() {
-     this.login();
    },
 
    methods: {
@@ -153,12 +148,9 @@
        })
      },
 
-     login() {
-       this.$store.dispatch('loadUser');
-     },
-
-     logout() {
-       this.$store.dispatch('logout');
+     async logout() {
+       await fetch('/logout', {credentials: 'include'});
+       await tokenAutorefresh.refreshJwt(true);
      }
    }
  }

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,4 +61,6 @@ const app = new Vue({
 })
 
 setErrorNotifier(app.$notify);
-(window as any).foo = (app as any).$apollo;
+
+import tokenAutorefresh from './tokenAutorefresh'
+tokenAutorefresh.addJwtListener((jwt, payload) => store.commit('setUser', payload));

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ import App from './App.vue';
 const isProd = process.env.NODE_ENV === 'production';
 
 import VueAnalytics from 'vue-analytics';
+import { setErrorNotifier } from './util'
 Vue.use(VueAnalytics, {
   id: 'UA-73509518-1',
   router,
@@ -46,7 +47,7 @@ Vue.use(VueAnalytics, {
 
 Vue.config.performance = true;
 
-new Vue({
+const app = new Vue({
   el: '#app',
   render: h => h(App),
     /*
@@ -58,3 +59,6 @@ new Vue({
   router,
   apolloProvider
 })
+
+setErrorNotifier(app.$notify);
+(window as any).foo = (app as any).$apollo;

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,8 +1,6 @@
 import apolloClient from '../graphqlClient';
 import {fetchOptionListsQuery} from '../api/metadata';
 import {decodeParams} from '../url';
-import { decodePayload } from '../util';
-import tokenAutorefresh from '../tokenAutorefresh';
 
 export default {
 
@@ -22,16 +20,4 @@ export default {
     context.commit('updateFilter', filter)
   },
 
-  async loadUser(context) {
-    const jwt = await tokenAutorefresh.getJwt();
-    const {name, email, role} = decodePayload(jwt);
-
-    context.commit('setUser', {name, email, role});
-  },
-
-  async logout(context) {
-    await fetch('/logout', {credentials: 'include'});
-    await tokenAutorefresh.refreshJwt(true);
-    await context.dispatch('loadUser');
-  },
 };

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,6 +1,8 @@
 import apolloClient from '../graphqlClient';
 import {fetchOptionListsQuery} from '../api/metadata';
 import {decodeParams} from '../url';
+import { decodePayload } from '../util';
+import tokenAutorefresh from '../tokenAutorefresh';
 
 export default {
 
@@ -18,5 +20,18 @@ export default {
     // Refresh the current filter so that computed defaults that depend on `filterLists` are applied
     const filter = decodeParams(context.state.route, context.state.filterLists)
     context.commit('updateFilter', filter)
-  }
+  },
+
+  async loadUser(context) {
+    const jwt = await tokenAutorefresh.getJwt();
+    const {name, email, role} = decodePayload(jwt);
+
+    context.commit('setUser', {name, email, role});
+  },
+
+  async logout(context) {
+    await fetch('/logout', {credentials: 'include'});
+    await tokenAutorefresh.refreshJwt(true);
+    await context.dispatch('loadUser');
+  },
 };

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -4,6 +4,9 @@ import {decodeParams,
         encodeParams, encodeSections, encodeSortOrder,
         stripFilteringParams} from '../url';
 import {getFilterInitialValue} from '../filterSpecs';
+import tokenAutorefresh from '../tokenAutorefresh';
+import {decodePayload} from '../util';
+
 
 function updatedLocation(state, filter) {
   let query = encodeParams(filter, state.route.path, state.filterLists);
@@ -85,14 +88,9 @@ export default {
     state.tableIsLoading = isLoading;
   },
 
-  login(state, user) {
-    state.authenticated = true;
+  setUser(state, user) {
+    state.authenticated = user != null && user.role !== 'anonymous';
     state.user = user;
-  },
-
-  logout(state) {
-    state.authenticated = false;
-    state.user = null;
   },
 
   startTour(state, tourDescription) {

--- a/src/tokenAutorefresh.ts
+++ b/src/tokenAutorefresh.ts
@@ -59,11 +59,6 @@ class TokenAutorefresh {
         errors++;
         if (errors > 5) {
           this.jwt = undefined;
-          try {
-            this.jwtListeners.forEach(listener => listener());
-          } catch (err) {
-            console.error(err);
-          }
         }
       }
     }

--- a/src/tokenAutorefresh.ts
+++ b/src/tokenAutorefresh.ts
@@ -31,6 +31,7 @@ class TokenAutorefresh {
       this.jwtPromise = undefined;
       this.jwtCanExpire = decodePayload(this.jwt).exp != null;
     }
+    return await this.getJwt();
   }
 
 

--- a/src/tokenAutorefresh.ts
+++ b/src/tokenAutorefresh.ts
@@ -1,22 +1,60 @@
-import { getJWT, decodePayload } from './util';
-import Vue from 'vue';
+import { getJWT, decodePayload, delay } from './util'
 
-class TokenAutorefresh extends Vue {
+const REFRESH_INTERVAL = 30000; // 30 seconds
+
+class TokenAutorefresh {
   jwt?: string;
-
-  private interval = 30000; // 30 seconds
+  jwtPromise?: Promise<string>;
+  jwtCanExpire: boolean = true;
 
   constructor() {
-    super();
-    this.execute();
+    this.runRefreshLoop();
   }
 
-  private async execute() {
-    this.jwt = await getJWT();
-    const payload = decodePayload(this.jwt);
-    const delay = payload.exp ? this.interval : 0; // update the token every 30 seconds
-    if (delay > 0)
-      window.setTimeout(() => this.execute(), delay);
+  async getJwt() {
+    while (this.jwt == null && this.jwtPromise != null) {
+      await this.jwtPromise;
+    }
+    return this.jwt;
+  }
+
+  async refreshJwt(invalidateOldJwt: boolean = false) {
+    if (invalidateOldJwt) {
+      this.jwt = undefined;
+    }
+    const promise = this.jwtPromise = getJWT();
+    const jwt = await promise;
+
+    // Only overwrite the jwt if another refresh hasn't started while this one has been waiting
+    if (this.jwtPromise === promise) {
+      this.jwt = jwt;
+      this.jwtPromise = undefined;
+      this.jwtCanExpire = decodePayload(this.jwt).exp != null;
+    }
+  }
+
+
+  private async runRefreshLoop() {
+    let errors = 0;
+    while (true) {
+      try {
+        if (!this.jwt || this.jwtCanExpire) {
+          await this.refreshJwt();
+          errors = 0;
+        }
+        await delay(REFRESH_INTERVAL);
+      } catch (err) {
+        // If there's an error, speed up the refresh cycle so that the user isn't left waiting too long after
+        // the issue is resolved
+        await delay(1000);
+
+        // Also clear the stored token so that an error message gets shown next time there's a request
+        errors++;
+        if (errors > 5) {
+          this.jwt = undefined;
+        }
+      }
+    }
   }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,11 +2,17 @@ import * as config from './clientConfig.json';
 import * as scales from 'plotly.js/src/components/colorscale/scales.js';
 import * as extractScale from 'plotly.js/src/components/colorscale/extract_scale.js';
 import * as d3 from 'd3';
+import { ElNotification } from 'element-ui/types/notification'
+import * as Raven from 'raven-js';
 
 const fuConfig = config.fineUploader;
 
 function prettifySign(str: string): string {
   return str.replace('-', ' – ').replace('+', ' + ');
+}
+
+function delay(timeMs: number) {
+  return new Promise(resolve => setTimeout(resolve, timeMs));
 }
 
 interface StringDictionary {
@@ -98,9 +104,27 @@ function mdTypeSupportsOpticalImages(mdType: string): boolean {
   return !mdTypesToSkipImages.includes(mdType);
 }
 
+let $notify: ElNotification;
+function setErrorNotifier(_$notify: ElNotification) {
+  $notify = _$notify;
+}
+
+function reportError(err: Error, message?: string) {
+  try {
+    Raven.captureException(err);
+    if ($notify != null) {
+      $notify.error(message || 'Oops! Something went wrong. Please refresh the page and try again.');
+    }
+  } catch(ex) {
+    console.error(ex);
+    /* Avoid breaking down-stream error handling  */
+  }
+}
+
 export {
   renderMolFormula,
   prettifySign,
+  delay,
   getJWT,
   decodePayload,
   pathFromUUID,
@@ -109,5 +133,7 @@ export {
   mzFilterPrecision,
   csvExportHeader,
   scrollDistance,
-  mdTypeSupportsOpticalImages
+  mdTypeSupportsOpticalImages,
+  setErrorNotifier,
+  reportError,
 };


### PR DESCRIPTION
Asana link: https://app.asana.com/0/474912821417535/694707053921715

* Instead of manually loading the VueX store's user in `MetadataHeader`, this adds a listener to `tokenAutorefresh` so that the VueX store is updated whenever a JWT token is received. This has the side effect of making it look like logout is broken on local development, as the server automatically logs you back in as `admin@localhost`. At least now the UI reflects reality correctly as previously you'd get the admin JWT but appear logged out.
* Never stop trying to refresh the JWT, even on server error. If there are 5 network errors in a row, it clears the JWT and starts showing the user an error message every time there's a server request. If the network comes back, the JWT will be fetched again. A side effect of clearing 