### PR TITLE
Prevent datasets in the dataset list from growing when text is too long

### DIFF
--- a/src/components/DatasetItem.vue
+++ b/src/components/DatasetItem.vue
@@ -23,11 +23,11 @@
     </div>
 
     <div class="ds-info">
-      <div>
+      <div class="ds-item-line">
         <b>{{ formatDatasetName }}</b>
       </div>
 
-      <div style="color: darkblue;">
+      <div class="ds-item-line" style="color: darkblue;">
         <span class="ds-add-filter"
               title="Filter by species"
               @click="addFilter('organism')">
@@ -43,7 +43,7 @@
           ({{ formatCondition }})</span>
       </div>
 
-      <div>
+      <div class="ds-item-line">
         <span class="ds-add-filter"
               title="Filter by ionisation source"
               @click="addFilter('ionisationSource')">
@@ -59,7 +59,7 @@
         RP {{ formatResolvingPower }}
       </div>
 
-      <div style="font-size: 15px;">
+      <div class="ds-item-line" style="font-size: 15px;">
         Submitted <span class="s-bold">{{ formatDate }}</span>
         at {{ formatTime }} by
         <span class="ds-add-filter"
@@ -71,7 +71,7 @@
               title="Filter by this lab"
               @click="addFilter('institution')"></span>
       </div>
-      <div v-if="dataset.status == 'FINISHED' && this.dataset.fdrCounts">
+      <div class="ds-item-line" v-if="dataset.status == 'FINISHED' && this.dataset.fdrCounts">
         <span>{{formatFdrCounts()}} annotations @ FDR {{formatFdrLevel()}}% ({{formatDbName()}})</span>
       </div>
     </div>
@@ -518,6 +518,11 @@
    height: 32px;
    right: 10px;
    bottom: 8px;
+ }
+ .ds-item-line {
+   overflow: hidden;
+   white-space: nowrap;
+   text-overflow: ellipsis;
  }
 
 </style>

--- a/src/components/DatasetTable.vue
+++ b/src/components/DatasetTable.vue
@@ -355,7 +355,7 @@
    display: flex;
    flex-direction: row;
    flex-wrap: wrap;
-   align-items: center;
+   align-items: stretch;
  }
 
  .cb-started .el-checkbox__input.is-checked .el-checkbox__inner {


### PR DESCRIPTION
Makes all rows in the dataset item table truncate text with `...` if its too long:
![image](https://user-images.githubusercontent.com/26366936/41049998-77bea564-69b2-11e8-84b2-b350c88817d7.png)

Also, this uses `align-items: stretch` so that if for any reason the text does wrap, side-by-side items on the grid have the same height:

![image](https://user-images.githubusercontent.com/26366936/41049982-6b49179c-69b2-11e8-8b51-40041224baa2.png)

(IIRC Internet Explorer still has bad support for ellipses, but Edge supports them)