### PR TITLE
Zoom is changed from wheel to slider on annotations page

### DIFF
--- a/src/components/AnnotationView.ts
+++ b/src/components/AnnotationView.ts
@@ -164,8 +164,8 @@
      this.$store.commit('updateAnnotationViewSections', activeSections)
    }
 
-   onImageZoom(event: any): void {
-     this.imagePosition.zoom = event.zoom;
+   onImageZoom(zoom: any): void {
+     this.imagePosition.zoom = zoom;
    }
 
    onImageMove(event: any): void {

--- a/src/components/AnnotationView.vue
+++ b/src/components/AnnotationView.vue
@@ -33,10 +33,10 @@
                      :opacity="opacity"
                      :imageLoaderSettings="imageLoaderSettings"
                      :zoom="imagePosition.zoom"
-                     v-on:zoom-input="onImageZoom"
+                     @zoom-input="onImageZoom"
                      :onImageMove="onImageMove"
                      :acquisitionGeometry="msAcqGeometry"
-                     v-on:opacityInput="newVal => opacity = newVal">
+                     @opacityInput="newVal => opacity = newVal">
           </component>
         </el-collapse-item>
 

--- a/src/components/AnnotationView.vue
+++ b/src/components/AnnotationView.vue
@@ -32,7 +32,8 @@
                      :colormapName="colormapName"
                      :opacity="opacity"
                      :imageLoaderSettings="imageLoaderSettings"
-                     :onImageZoom="onImageZoom"
+                     :zoom="imagePosition.zoom"
+                     v-on:zoom-input="onImageZoom"
                      :onImageMove="onImageMove"
                      :acquisitionGeometry="msAcqGeometry"
                      v-on:opacityInput="newVal => opacity = newVal">

--- a/src/components/ImageLoader.vue
+++ b/src/components/ImageLoader.vue
@@ -6,10 +6,12 @@
        v-resize.debounce.50="onResize"
        :element-loading-text="message">
 
-    <div class="image-loader__container"
-         ref="container" style="align-self: center">
+    <div class="image-loader__container" ref="container" style="align-self: center">
       <div style="text-align: left; z-index: 2; position: relative">
-        <img :src="dataURI" :style="imageStyle" v-on:click="onClick" ref="visibleImage"
+        <img :src="dataURI"
+             :style="imageStyle"
+             @click="onClick"
+             ref="visibleImage"
              class="isotope-image"/>
       </div>
 
@@ -82,6 +84,10 @@
      transform: {
        type: String,
        default: ''
+     },
+     halfWidth: {
+       type: Boolean,
+       default: false
      }
    },
    data () {
@@ -123,17 +129,8 @@
      window.removeEventListener('resize', this.onResize);
    },
    computed: {
-     routeAnnotationsCheck() {
-       if (this.$router.currentRoute.path === '/annotations') {
-         return true
-       }
-       else {
-         return false
-       }
-     },
-
      hideImage() {
-       if (this.routeAnnotationsCheck) {
+       if (this.halfWidth) {
          return 'overflow: hidden;'
        }
      },
@@ -157,21 +154,14 @@
            'width': width + 'px',
            'height': height + 'px',
             transform: transform + ' ' + this.transform,
-           'transform-origin': this.routeAnnotationsCheck ? '50% 50% 0' : '0 0',
-           'clipPath': this.routeAnnotationsCheck ? '' : clipPath,
+           'transform-origin': this.halfWidth ? '50% 50% 0' : '0 0',
+           'clipPath': this.halfWidth ? '' : clipPath,
          };
        } else // LC-MS data (1 x number of time points)
        return {
          width: '100%',
          height: Math.min(100, this.maxHeight) + 'px'
        };
-     },
-
-     imageContainerStyle() {
-       return {
-         width: this.imageWidth + 'px',
-         'align-self': 'center'
-       }
      },
 
      opticalImageStyle() {
@@ -394,12 +384,15 @@
        return this.image;
      },
 
-     getScaleFactor() {
-       return this.scaleFactor;
+     getParent() {
+       return this.$refs.parent;
      },
 
-     getContainer() {
-       return this.$refs.container;
+     getScaledImageSize() {
+       return {
+         'imgWidth': this.$refs.visibleImage.getBoundingClientRect().width,
+         'imgHeight': this.$refs.visibleImage.getBoundingClientRect().height
+       }
      }
    }
  }

--- a/src/components/annotation-widgets/default/MainImage.vue
+++ b/src/components/annotation-widgets/default/MainImage.vue
@@ -5,6 +5,7 @@
                       :colormap="colormap"
                       :max-height=500
                       ref="imageLoader"
+                      :half-width=halfWidth
                       v-bind="imageLoaderSettings"
                       @move="onImageMove">
         </image-loader>
@@ -16,7 +17,7 @@
                         vertical
                         height="150px"
                         :value="opacity"
-                        v-on:input="onOpacityInput"
+                        @input="onOpacityInput"
                         :min=0
                         :max=1
                         :step=0.01
@@ -46,7 +47,7 @@
             width="100%"
             label="Zoom"
             :value="zoomVal"
-            v-on:input="onZoomInput"
+            @input="onZoomInput"
             :min=1
             :max=10
             :step="0.1"
@@ -99,12 +100,13 @@ export default class MainImage extends Vue {
     }
 
     saveImage(event: any): void {
-      let node = this.$refs.imageLoader.$refs.parent
+      let node = this.$refs.imageLoader.getParent(),
+          {imgWidth, imgHeight} = this.$refs.imageLoader.getScaledImageSize();
 
       domtoimage
         .toBlob(node, {
-          width: node.getBoundingClientRect().width,
-          height:  node.getBoundingClientRect().height
+          width: imgWidth >= node.clientWidth ? node.clientWidth : imgWidth,
+          height:  imgHeight >= node.clientHeight ? node.clientHeight : imgHeight
         })
         .then(blob => {
           saveAs(blob, `${this.annotation.id}.png`);
@@ -121,6 +123,15 @@ export default class MainImage extends Vue {
 
     onZoomInput(val: number): void {
       this.$emit('zoom-input', val)
+    }
+
+    get halfWidth(): boolean {
+      if (this.$router.currentRoute.path === '/annotations') {
+        return true
+      }
+      else {
+        return false
+      }
     }
 }
 </script>

--- a/src/components/annotation-widgets/default/MainImage.vue
+++ b/src/components/annotation-widgets/default/MainImage.vue
@@ -5,7 +5,7 @@
                       :colormap="colormap"
                       :max-height=500
                       ref="imageLoader"
-                      :half-width=halfWidth
+                      half-width
                       v-bind="imageLoaderSettings"
                       @move="onImageMove">
         </image-loader>
@@ -123,15 +123,6 @@ export default class MainImage extends Vue {
 
     onZoomInput(val: number): void {
       this.$emit('zoom-input', val)
-    }
-
-    get halfWidth(): boolean {
-      if (this.$router.currentRoute.path === '/annotations') {
-        return true
-      }
-      else {
-        return false
-      }
     }
 }
 </script>

--- a/src/components/annotation-widgets/default/MainImage.vue
+++ b/src/components/annotation-widgets/default/MainImage.vue
@@ -1,43 +1,57 @@
 <template>
 <div class="main-ion-image-container">
-    <image-loader :src="annotation.isotopeImages[0].url"
-                  :colormap="colormap"
-                  :max-height=500
-                  ref="imageLoader"
-                  v-bind="imageLoaderSettings"
-                  @zoom="onImageZoom"
-                  @move="onImageMove">
-    </image-loader>
+    <div class="main-ion-image-container-row1">
+        <image-loader :src="annotation.isotopeImages[0].url"
+                      :colormap="colormap"
+                      :max-height=500
+                      ref="imageLoader"
+                      v-bind="imageLoaderSettings"
+                      @move="onImageMove">
+        </image-loader>
 
-    <div class="colorbar-container">
-        <div v-if="imageLoaderSettings.opticalImageUrl">
-        Opacity:
+        <div class="colorbar-container">
+            <div v-if="imageLoaderSettings.opticalImageUrl">
+                Opacity:
+                <el-slider
+                        vertical
+                        height="150px"
+                        :value="opacity"
+                        v-on:input="onOpacityInput"
+                        :min=0
+                        :max=1
+                        :step=0.01
+                        style="margin: 10px 0px 30px 0px;">
+                </el-slider>
+            </div>
+
+            {{ annotation.isotopeImages[0].maxIntensity.toExponential(2) }}
+            <colorbar style="width: 20px; height: 160px; align-self: center;"
+                      :direction="colorbarDirection" :map="colormapName"
+                      slot="reference">
+            </colorbar>
+            {{ annotation.isotopeImages[0].minIntensity.toExponential(2) }}
+
+            <div class="annot-view__image-download" v-if="browserSupportsDomToImage">
+                <!-- see https://github.com/tsayen/dom-to-image/issues/155 -->
+                <img src="../../../assets/download-icon.png"
+                     width="32px"
+                     title="Save visible region in PNG format"
+                     @click="saveImage"/>
+            </div>
+        </div>
+    </div>
+    <div class="main-ion-image-container-row2">
+        Zoom:
         <el-slider
-            vertical
-            height="150px"
-            :value="opacity"
-            v-on:input="onOpacityInput"
-            :min=0
-            :max=1
-            :step=0.01
-            style="margin: 10px 0px 30px 0px;">
+            width="100%"
+            label="Zoom"
+            :value="zoomVal"
+            v-on:input="onZoomInput"
+            :min=1
+            :max=10
+            :step="0.1"
+            style="margin: 0">
         </el-slider>
-        </div>
-
-        {{ annotation.isotopeImages[0].maxIntensity.toExponential(2) }}
-        <colorbar style="width: 20px; height: 160px; align-self: center;"
-                  :direction="colorbarDirection" :map="colormapName"
-                  slot="reference">
-        </colorbar>
-        {{ annotation.isotopeImages[0].minIntensity.toExponential(2) }}
-
-        <div class="annot-view__image-download" v-if="browserSupportsDomToImage">
-        <!-- see https://github.com/tsayen/dom-to-image/issues/155 -->
-        <img src="../../../assets/download-icon.png"
-             width="32px"
-             title="Save visible region in PNG format"
-             @click="saveImage"/>
-        </div>
     </div>
 </div>
 </template>
@@ -68,25 +82,29 @@ export default class MainImage extends Vue {
     @Prop({required: true, type: String})
     colormapName!: string
     @Prop({required: true, type: Number})
+    zoom!: number
+    @Prop({required: true, type: Number})
     opacity!: number
     @Prop({required: true})
     imageLoaderSettings!: any
     @Prop({required: true, type: Function})
     onImageMove!: Function
-    @Prop({required: true, type: Function})
-    onImageZoom!: Function
+
+    get zoomVal(): number {
+      return this.zoom
+    }
 
     get colorbarDirection(): string {
       return this.colormap[0] == '-' ? 'bottom' : 'top';
     }
 
     saveImage(event: any): void {
-      let node = this.$refs.imageLoader.getContainer();
+      let node = this.$refs.imageLoader.$refs.parent
 
       domtoimage
         .toBlob(node, {
-          width: this.$refs.imageLoader.imageWidth,
-          height: this.$refs.imageLoader.imageHeight
+          width: node.getBoundingClientRect().width,
+          height:  node.getBoundingClientRect().height
         })
         .then(blob => {
           saveAs(blob, `${this.annotation.id}.png`);
@@ -100,14 +118,28 @@ export default class MainImage extends Vue {
     onOpacityInput(val: number): void {
       this.$emit('opacityInput', val);
     }
+
+    onZoomInput(val: number): void {
+      this.$emit('zoom-input', val)
+    }
 }
 </script>
 
 <style>
 .main-ion-image-container {
     display: flex;
+    flex-direction: column;
+}
+
+.main-ion-image-container-row1 {
+    display: flex;
     flex-direction: row;
     justify-content: center;
+}
+
+.main-ion-image-container-row2 {
+    padding: 0 30%;
+    margin: 15px 0 0 0;
 }
 
 .colorbar-container {


### PR DESCRIPTION
- The slider was added under the Ion image on annotations page.
- The previous method to process mouse wheel event was deleted.
- The value of Zoom is set up on MainImage component from `v-on:input="onZoomInput"` and the ` onZoomInput` method emits the `zoom-input` event which is processed in AnnotationView.ts
- Ion image+optical image can be properly saved (the viewport of the image is saved).
- When zooming image will be taking the available space on the left and right sides. 