### PR TITLE
SEO audit fixes & bundle size optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ build/Release
 
 # Compiled output
 dist
+stats.json
 
 # Dependency directories
 node_modules

--- a/analyze-size.sh
+++ b/analyze-size.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
-NODE_ENV=production webpack --profile --json | tail -n +2 > stats.json
-webpack-bundle-analyzer stats.json dist/ -p 9900 -O
+
+rm -rf dist
+NODE_ENV=production npx webpack --profile --json | tail -n +3 > stats.json
+du -c dist/*.js
+npx webpack-bundle-analyzer stats.json dist/ -p 9900 -O

--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="Description" content="Platform for metabolite annotation of imaging mass spectrometry data">
     <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
     <script>
      var $buoop = {vs:{i:10,f:-8,o:-4,s:8,c:-8},api:4};
@@ -22,6 +24,6 @@
     <script src="/dist/vendor.bundle.js"></script>
     <script src="/dist/app.js?v=0.8"></script>
     <script type="text/javascript" id="cookiebanner"
-            src="https://cdnjs.cloudflare.com/ajax/libs/cookie-banner/1.0.0/cookiebanner.min.js"></script>
+            src="https://cdnjs.cloudflare.com/ajax/libs/cookie-banner/1.2.2/cookiebanner.min.js"></script>
   </body>
 </html>

--- a/src/components/Colorbar.vue
+++ b/src/components/Colorbar.vue
@@ -4,7 +4,7 @@
 </template>
 
 <script lang="ts">
- import {getColorScale} from '../util';
+ import getColorScale from '../lib/getColorScale';
  import Vue, { ComponentOptions } from 'vue';
 
  export default Vue.extend({

--- a/src/components/DatasetTable.vue
+++ b/src/components/DatasetTable.vue
@@ -331,6 +331,12 @@
    align-items: center;
  }
 
+ .export-btn {
+   margin-top: 7px;
+   width: 135px;
+   height: 36px;
+ }
+
  .cb-started .el-checkbox__input.is-checked .el-checkbox__inner {
    background: #5eed5e;
  }

--- a/src/components/DatasetTable.vue
+++ b/src/components/DatasetTable.vue
@@ -1,59 +1,47 @@
 <template>
-  <div id="dataset-page">
-    <div id="dataset-page-contents">
-      <div id="dataset-page-head">
-        <filter-panel level="dataset"></filter-panel>
+  <div>
+    <filter-panel level="dataset"></filter-panel>
 
-        <div>
-          <el-form :inline="true" style="display: inline-flex">
-            <el-radio-group v-model="displayMode" size="small">
-              <el-radio-button label="List"></el-radio-button>
-              <el-radio-button label="Summary"></el-radio-button>
-            </el-radio-group>
+    <div>
+      <el-form :inline="true" style="display: inline-flex">
+        <el-radio-group value="List" @input="onChangeTab" size="small">
+          <el-radio-button label="List"></el-radio-button>
+          <el-radio-button label="Summary"></el-radio-button>
+        </el-radio-group>
 
-            <el-checkbox-group v-model="categories" :min=1 style="padding: 5px 20px;"
-                               v-if="displayMode == 'List'">
-              <el-checkbox class="cb-started" label="started">Processing {{ count('started') }}</el-checkbox>
-              <el-checkbox class="cb-queued" label="queued">Queued {{ count('queued') }}</el-checkbox>
-              <el-checkbox label="finished">Finished {{ count('finished') }}</el-checkbox>
-            </el-checkbox-group>
-          </el-form>
+        <el-checkbox-group v-model="categories" :min=1 style="padding: 5px 20px;">
+          <el-checkbox class="cb-started" label="started">Processing {{ count('started') }}</el-checkbox>
+          <el-checkbox class="cb-queued" label="queued">Queued {{ count('queued') }}</el-checkbox>
+          <el-checkbox label="finished">Finished {{ count('finished') }}</el-checkbox>
+        </el-checkbox-group>
+      </el-form>
+    </div>
+
+    <div>
+      <div id="dataset-list-header">
+        <div v-if="noFilters" style="font: 24px 'Roboto', sans-serif; padding: 5px;">
+          <span v-if="noFilters">
+            Recent uploads
+          </span>
         </div>
 
-        <div v-if="displayMode == 'List'">
-          <div id="dataset-list-header">
-            <div v-if="noFilters" style="font: 24px 'Roboto', sans-serif; padding: 5px;">
-              <span v-if="noFilters">
-                Recent uploads
-              </span>
-            </div>
-
-            <div v-else style="font: 18px 'Roboto', sans-serif; padding: 5px;">
-              <span v-if="nonEmpty">
-                Search results in reverse chronological order
-              </span>
-              <span v-else>No datasets found</span>
-            </div>
-
-            <el-button v-if="nonEmpty" :disabled="isExporting" @click="startExport" class="export-btn">
-              Export to CSV
-            </el-button>
-          </div>
-
-          <div class="dataset-list">
-            <dataset-item v-for="(dataset, i) in datasets"
-                          :dataset="dataset" :key="dataset.id"
-                          :class="[i%2 ? 'even': 'odd']">
-            </dataset-item>
-          </div>
+        <div v-else style="font: 18px 'Roboto', sans-serif; padding: 5px;">
+          <span v-if="nonEmpty">
+            Search results in reverse chronological order
+          </span>
+          <span v-else>No datasets found</span>
         </div>
 
-        <div v-else id="dataset-summary-charts">
-          <upload-timeline-plot></upload-timeline-plot>
-          <submitter-summary-plot></submitter-summary-plot>
-          <mass-spec-setup-plot></mass-spec-setup-plot>
-          <organism-summary-plot></organism-summary-plot>
-        </div>
+        <el-button v-if="nonEmpty" :disabled="isExporting" @click="startExport" class="export-btn">
+          Export to CSV
+        </el-button>
+      </div>
+
+      <div class="dataset-list">
+        <dataset-item v-for="(dataset, i) in datasets"
+                      :dataset="dataset" :key="dataset.id"
+                      :class="[i%2 ? 'even': 'odd']">
+        </dataset-item>
       </div>
     </div>
   </div>
@@ -64,10 +52,6 @@
  import {metadataExportQuery} from '../api/metadata';
  import DatasetItem from './DatasetItem.vue';
  import FilterPanel from './FilterPanel.vue';
- import MassSpecSetupPlot from './plots/MSSetupSummaryPlot.vue';
- import OrganismSummaryPlot from './plots/OrganismSummaryPlot.vue';
- import SubmitterSummaryPlot from './plots/SubmitterSummaryPlot.vue';
- import UploadTimelinePlot from './plots/DatasetUploadTimeline.vue';
  import {csvExportHeader} from '../util';
  import gql from 'graphql-tag';
  import FileSaver from 'file-saver';
@@ -87,10 +71,6 @@
    components: {
      DatasetItem,
      FilterPanel,
-     MassSpecSetupPlot,
-     OrganismSummaryPlot,
-     SubmitterSummaryPlot,
-     UploadTimelinePlot
    },
 
    computed: {
@@ -112,15 +92,6 @@
            list = list.concat(this[category]);
        return list;
      },
-
-     displayMode: {
-       get() {
-         return this.$store.getters.settings.datasets.tab;
-       },
-       set(value) {
-         this.$store.commit('setCurrentTab', value);
-       }
-     }
    },
 
    apollo: {
@@ -314,12 +285,16 @@
        }
 
        runExport();
+     },
+
+     onChangeTab(tab) {
+       this.$store.commit('setDatasetTab', tab);
      }
    }
  }
 </script>
 
-<style>
+<style lang="scss">
 
  #dataset-page {
    display: flex;
@@ -330,25 +305,23 @@
  #dataset-page-contents {
    display: inline-block;
    width: 820px;
+
+   @media (min-width: 1650px) {
+     /* 2 datasets per row on wide screens */
+     width: 1620px;
+   }
  }
 
  .even {
    background-color: #e6f1ff;
+
+   @media (min-width: 1650px) {
+     background-color: white;
+   }
  }
 
  .odd {
    background-color: white;
- }
-
- /* 2 datasets per row on wide screens */
- @media (min-width: 1650px) {
-   #dataset-page-contents {
-     width: 1620px;
-   }
-
-   .even {
-     background-color: white !important;
-   }
  }
 
  .dataset-list {
@@ -364,13 +337,6 @@
 
  .cb-queued .el-checkbox__input.is-checked .el-checkbox__inner {
    background: #72c8e5;
- }
-
- #dataset-summary-charts {
-   flex-flow: row wrap;
-   display: flex;
-   justify-content: space-around;
-   padding-bottom: 50px;
  }
 
  #dataset-list-header {

--- a/src/components/DatasetsPage.vue
+++ b/src/components/DatasetsPage.vue
@@ -1,6 +1,10 @@
 <template>
   <el-row>
-    <router-view></router-view>
+    <div id="dataset-page">
+      <div id="dataset-page-contents">
+        <router-view></router-view>
+      </div>
+    </div>
   </el-row>
 </template>
 
@@ -13,3 +17,22 @@
    }
  }
 </script>
+
+<style lang="scss">
+
+  #dataset-page {
+    display: flex;
+    justify-content: center;
+  }
+
+  /* 1 dataset per row by default*/
+  #dataset-page-contents {
+    display: inline-block;
+    width: 820px;
+
+    @media (min-width: 1650px) {
+      /* 2 datasets per row on wide screens */
+      width: 1620px;
+    }
+  }
+</style>

--- a/src/components/ImageLoader.vue
+++ b/src/components/ImageLoader.vue
@@ -27,7 +27,8 @@
 <script>
  // uses loading directive from Element-UI
 
- import {createColormap, scrollDistance} from '../util';
+ import {scrollDistance} from '../util';
+ import createColormap from '../lib/createColormap';
  import {quantile} from 'simple-statistics';
  import resize from 'vue-resize-directive';
  import config from '../clientConfig.json';

--- a/src/components/plots/DatasetSummary.vue
+++ b/src/components/plots/DatasetSummary.vue
@@ -1,0 +1,52 @@
+<template>
+  <div>
+    <filter-panel level="dataset"></filter-panel>
+
+    <div>
+      <el-form :inline="true" style="display: inline-flex">
+        <el-radio-group value="Summary" @input="onChangeTab" size="small">
+          <el-radio-button label="List"></el-radio-button>
+          <el-radio-button label="Summary"></el-radio-button>
+        </el-radio-group>
+      </el-form>
+    </div>
+
+    <div id="dataset-summary-charts">
+      <upload-timeline-plot></upload-timeline-plot>
+      <submitter-summary-plot></submitter-summary-plot>
+      <mass-spec-setup-plot></mass-spec-setup-plot>
+      <organism-summary-plot></organism-summary-plot>
+    </div>
+  </div>
+</template>
+<script>
+  import UploadTimelinePlot from './DatasetUploadTimeline.vue';
+  import SubmitterSummaryPlot from './SubmitterSummaryPlot.vue';
+  import MassSpecSetupPlot from './MSSetupSummaryPlot.vue';
+  import OrganismSummaryPlot from './OrganismSummaryPlot.vue';
+  import FilterPanel from '../FilterPanel.vue';
+
+
+  export default {
+    components: {
+      FilterPanel,
+      UploadTimelinePlot,
+      SubmitterSummaryPlot,
+      MassSpecSetupPlot,
+      OrganismSummaryPlot,
+    },
+    methods: {
+      onChangeTab(tab) {
+        this.$store.commit('setDatasetTab', tab);
+      }
+    }
+  }
+</script>
+<style>
+  #dataset-summary-charts {
+    flex-flow: row wrap;
+    display: flex;
+    justify-content: space-around;
+    padding-bottom: 50px;
+  }
+</style>

--- a/src/graphqlClient.ts
+++ b/src/graphqlClient.ts
@@ -2,7 +2,7 @@ import {ApolloClient, createBatchingNetworkInterface } from 'apollo-client';
 import {SubscriptionClient, addGraphQLSubscriptions} from 'subscriptions-transport-ws';
 import * as config from './clientConfig.json';
 import tokenAutorefresh from './tokenAutorefresh';
-import { reportError } from './util'
+import reportError from './lib/reportError'
 
 const networkInterface = createBatchingNetworkInterface({
   uri: config.graphqlUrl,

--- a/src/lib/createColormap.ts
+++ b/src/lib/createColormap.ts
@@ -1,0 +1,14 @@
+import * as d3 from 'd3';
+import getColorScale from './getColorScale';
+
+export default function createColormap(name: string): number[][] {
+  const {domain, range} = getColorScale(name);
+  const sclFun = d3.scaleLinear<d3.RGBColor>().domain(domain).range(range).clamp(true);
+
+  let colors = [];
+  for (let i = 0; i < 256; i++) {
+    const color = d3.rgb(sclFun(i / 255.0));
+    colors.push([color.r, color.g, color.b].map(Math.round));
+  }
+  return colors;
+}

--- a/src/lib/getColorScale.ts
+++ b/src/lib/getColorScale.ts
@@ -1,0 +1,16 @@
+import * as d3 from 'd3';
+import * as scales from 'plotly.js/src/components/colorscale/scales.js';
+import * as extractScale from 'plotly.js/src/components/colorscale/extract_scale.js';
+
+interface ColorScale {
+  domain: number[]
+  range: d3.RGBColor[]
+}
+
+export default function getColorScale(name: string): ColorScale {
+  if (name[0] != '-')
+    return extractScale(scales[name], 0, 1); // normal
+  else
+    return extractScale(scales[name.slice(1)], 1, 0); // inverted
+}
+

--- a/src/lib/reportError.ts
+++ b/src/lib/reportError.ts
@@ -1,0 +1,20 @@
+import { ElNotification } from 'element-ui/types/notification';
+import * as Raven from 'raven-js';
+
+let $notify: ElNotification;
+
+export function setErrorNotifier(_$notify: ElNotification) {
+  $notify = _$notify;
+}
+
+export default function reportError(err: Error, message?: string) {
+  try {
+    Raven.captureException(err);
+    if ($notify != null) {
+      $notify.error(message || 'Oops! Something went wrong. Please refresh the page and try again.');
+    }
+  } catch (ex) {
+    console.error(ex);
+    /* Avoid breaking down-stream error handling  */
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ import App from './App.vue';
 const isProd = process.env.NODE_ENV === 'production';
 
 import VueAnalytics from 'vue-analytics';
-import { setErrorNotifier } from './util'
+import { setErrorNotifier } from './lib/reportError'
 Vue.use(VueAnalytics, {
   id: 'UA-73509518-1',
   router,

--- a/src/router.ts
+++ b/src/router.ts
@@ -12,14 +12,21 @@ const router = new VueRouter({
       path: '/datasets',
       component: DatasetsPage,
       children: [
-        {path: '', component: async () => await import(/* webpackPrefetch: true, webpackChunkName: "DatasetTable" */ './components/DatasetTable.vue')},
-        {path: 'edit/:dataset_id', component: async () => await import(/* webpackPrefetch: true, webpackChunkName: "MetadataEditPage" */ './components/MetadataEditPage.vue'), name: 'edit-metadata'},
-        {
-          path: ':dataset_id/add-optical-image',
-          name: 'add-optical-image',
-          component: async () => await import(/* webpackPrefetch: true, webpackChunkName: "ImageAlignmentPage" */ './components/ImageAlignmentPage.vue')
-        }
+        {path: '', redirect: 'list'},
+        {path: 'list', component: async () => await import(/* webpackPrefetch: true, webpackChunkName: "DatasetTable" */ './components/DatasetTable.vue')},
+        {path: 'summary', component: async () => await import(/* webpackPrefetch: true, webpackChunkName: "DatasetSummary" */ './components/plots/DatasetSummary.vue')},
       ]
+    },
+
+    {
+      path: '/datasets/edit/:dataset_id',
+      component: async () => await import(/* webpackPrefetch: true, webpackChunkName: "MetadataEditPage" */ './components/MetadataEditPage.vue'),
+      name: 'edit-metadata'
+    },
+    {
+      path: '/datasets/:dataset_id/add-optical-image',
+      name: 'add-optical-image',
+      component: async () => await import(/* webpackPrefetch: true, webpackChunkName: "ImageAlignmentPage" */ './components/ImageAlignmentPage.vue')
     },
     {
       path: '/upload',

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -129,8 +129,10 @@ export default {
     router.replace({query});
   },
 
-  setCurrentTab(state, tab) {
-    let query = Object.assign({}, state.route.query, {tab});
-    router.replace({query});
+  setDatasetTab(state, tab) {
+    router.replace({
+      path: `/datasets/${tab.toLowerCase()}`,
+      query: state.route.query,
+    });
   }
 };

--- a/src/url.ts
+++ b/src/url.ts
@@ -34,11 +34,13 @@ const URL_TO_FILTER: Dictionary<string> = invert(FILTER_TO_URL);
 const PATH_TO_LEVEL: Dictionary<string> = {
   '/annotations': 'annotation',
   '/datasets': 'dataset',
+  '/datasets/list': 'dataset',
+  '/datasets/summary': 'dataset',
   '/upload': 'upload'
 };
 
 export function encodeParams(filter: any, path: string, filterLists: any): Dictionary<string> {
-  const level = PATH_TO_LEVEL[path];
+  const level = PATH_TO_LEVEL[path.toLowerCase()];
   const defaultFilter = getDefaultFilter(level, filterLists);
 
   let q: Dictionary<string> = {};

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,4 @@
 import * as config from './clientConfig.json';
-import { ElNotification } from 'element-ui/types/notification'
-import * as Raven from 'raven-js';
 
 const fuConfig = config.fineUploader;
 
@@ -77,22 +75,6 @@ function mdTypeSupportsOpticalImages(mdType: string): boolean {
   return !mdTypesToSkipImages.includes(mdType);
 }
 
-let $notify: ElNotification;
-function setErrorNotifier(_$notify: ElNotification) {
-  $notify = _$notify;
-}
-
-function reportError(err: Error, message?: string) {
-  try {
-    Raven.captureException(err);
-    if ($notify != null) {
-      $notify.error(message || 'Oops! Something went wrong. Please refresh the page and try again.');
-    }
-  } catch(ex) {
-    console.error(ex);
-    /* Avoid breaking down-stream error handling  */
-  }
-}
 
 export {
   renderMolFormula,
@@ -105,6 +87,4 @@ export {
   csvExportHeader,
   scrollDistance,
   mdTypeSupportsOpticalImages,
-  setErrorNotifier,
-  reportError,
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,4 @@
 import * as config from './clientConfig.json';
-import * as scales from 'plotly.js/src/components/colorscale/scales.js';
-import * as extractScale from 'plotly.js/src/components/colorscale/extract_scale.js';
-import * as d3 from 'd3';
 
 const fuConfig = config.fineUploader;
 
@@ -47,30 +44,6 @@ function pathFromUUID(uuid: string): string {
     return fuConfig.storage + '/' + uuid + '/';
 }
 
-interface ColorScale {
-  domain: number[]
-  range: d3.RGBColor[]
-}
-
-function getColorScale(name: string): ColorScale {
-  if (name[0] != '-')
-    return extractScale(scales[name], 0, 1); // normal
-  else
-    return extractScale(scales[name.slice(1)], 1, 0); // inverted
-}
-
-function createColormap(name: string): number[][] {
-  const {domain, range} = getColorScale(name);
-  const sclFun = d3.scaleLinear<d3.RGBColor>().domain(domain).range(range).clamp(true);
-
-  let colors = [];
-  for (let i = 0; i < 256; i++) {
-    const color = d3.rgb(sclFun(i / 255.0));
-    colors.push([color.r, color.g, color.b].map(Math.round));
-  }
-  return colors;
-}
-
 function mzFilterPrecision(value: number): string {
   const splitVal = (value + '').split('.');
   if (splitVal.length == 1) {
@@ -104,8 +77,6 @@ export {
   getJWT,
   decodePayload,
   pathFromUUID,
-  getColorScale,
-  createColormap,
   mzFilterPrecision,
   csvExportHeader,
   scrollDistance,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -70,8 +70,8 @@ module.exports.optimization = {
         test: /[\\/]node_modules[\\/]/,
         chunks: 'initial'
       },
+      vendors: false,
       default: {
-        minChunks: 2,
         priority: -20,
         reuseExistingChunk: true
       }


### PR DESCRIPTION
#### SEO fixes as recommended per Chrome's Audit tool:
* Added `viewport` and `Description` `<meta>` tags
* Upgraded cookie-banner as the older version had a SEO-unfriendly link to an external site

#### Optimizing bundle size:
* Changed `analyze-size.sh` so that it can be run without any globally installed packages
* Moved `getColorScale` and `createColormap` out of `util.ts`, so that not every page automatically depended on d3
* Split up `DatasetTable.vue` from `DatasetSummary.vue`, as the latter requires d3 which is ~200kB before gzip.
* Moved `MetadataEditPage` and `ImageAlignmentPage` out of the `DatasetsPage` router tree as they didn't seem to actually use anything from `DatasetsPage`.
* Change webpack to stop creating "vendors" bundles. Previously it would create two bundles e.g. `AnnotationsPage.js` to store our code for a page, as well as `vendors~AnnotationsPage.js` to store the vendor code specific to that page. The page-specific bundles are already small and granular, so it didn't make sense to further split them up. This doesn't affect the existing `vendor.bundle.js`, which still contains roughly 50% of the JS code of the whole application. 



## Bundle size before (sizes in kB, minified but not gzipped):

* NOTE: The most important stats here are: `app.js` + `vendor.bundle.js` - the amount needed to load the front page, which is important for both new users and SEO; and `total`, which is indicative of the overall speed of the site*

![image](https://user-images.githubusercontent.com/26366936/41245292-ed2b2bc6-6da7-11e8-9235-90aa3d34893c.png)

```
80	dist/AnnotationsPage.js
260	dist/app.js
56	dist/DatasetTable.js
12	dist/HelpPage.js
40	dist/ImageAlignmentPage.js
8	dist/MetadataEditPage.js
32	dist/MetadataEditPage~UploadPage.js
20	dist/UploadPage.js
1232	dist/vendor.bundle.js
32	dist/vendors~AnnotationsPage~ImageAlignmentPage.js
16	dist/vendors~AnnotationsPage.js
68	dist/vendors~ImageAlignmentPage.js
12	dist/vendors~MetadataEditPage~UploadPage.js
208	dist/vendors~UploadPage.js
2076	total

```

## Bundle size after (sizes in kB, minified but not gzipped):
![image](https://user-images.githubusercontent.com/26366936/41245182-9dc279ae-6da7-11e8-83f9-f53849438ed1.png)

```
212	dist/AnnotationsPage~DatasetSummary~ImageAlignmentPage.js
56	dist/AnnotationsPage~ImageAlignmentPage.js
76	dist/AnnotationsPage.js
260	dist/app.js
28	dist/DatasetSummary.js
36	dist/DatasetTable.js
12	dist/HelpPage.js
92	dist/ImageAlignmentPage.js
8	dist/MetadataEditPage.js
40	dist/MetadataEditPage~UploadPage.js
228	dist/UploadPage.js
1016	dist/vendor.bundle.js
2064	total
```
